### PR TITLE
Update on GitHub syntax

### DIFF
--- a/Nvidia_JTX2_JP42/Ubuntu/1_create_base_image_tx2_JP42.txt
+++ b/Nvidia_JTX2_JP42/Ubuntu/1_create_base_image_tx2_JP42.txt
@@ -32,8 +32,8 @@ su apsync
 cd ~
 
 # clone the Apsync git
-mkdir Github
-pushd Github
+mkdir GitHub
+pushd GitHub
 
 # insert here the link to the master repository
 # my repository until we have a stable version ready 

--- a/Nvidia_JTX2_JP42/Ubuntu/1_create_base_image_tx2_JP42.txt
+++ b/Nvidia_JTX2_JP42/Ubuntu/1_create_base_image_tx2_JP42.txt
@@ -88,6 +88,7 @@ time sudo ./install_pymavlink # new version required for apweb #1m
 # install APWeb. We are installing a modified version which supports APStreamline and the necessary TX2 modifications
 time sudo ./install_apweb # 2m 
 # Optionally install APStreamline. Note that you need to have meson and ninja installed. The script takes care but you may need to check that you also have pip3 installed
+time sudo -E apt-get install -y python3-pip 
 sudo ./setup_APStreamline.sh
 
 Step 4: Testing

--- a/Nvidia_JTX2_JP42/Ubuntu/install_apweb
+++ b/Nvidia_JTX2_JP42/Ubuntu/install_apweb
@@ -28,7 +28,7 @@ cp autostart_apweb.sh \$APWEB_HOME/
 
 # we need to install a modified version of apweb to support APStreamline
 # this repository includes defect fixes and the necessary adoptions for the TX2
-pushd ~/Github
+pushd ~/GitHub
 rm -rf APWeb
 git clone -b video_streaming https://github.com/mtbsteve/APWeb.git
 pushd APWeb

--- a/Nvidia_JTX2_JP42/Ubuntu/setup_APStreamline.sh
+++ b/Nvidia_JTX2_JP42/Ubuntu/setup_APStreamline.sh
@@ -25,7 +25,7 @@ set -x
 # please also follow the wiki for APStreamline on github
 pushd ~/GitHub
 rm -rf adaptive-streaming
-git clone -b video_streaming https://github.com/mtbsteve/APWeb.git
+git clone https://github.com/mtbsteve/adaptive-streaming.git
 pushd adaptive-streaming
 meson build
 cd build

--- a/Nvidia_JTX2_JP42/Ubuntu/setup_APStreamline.sh
+++ b/Nvidia_JTX2_JP42/Ubuntu/setup_APStreamline.sh
@@ -23,7 +23,7 @@ set -x
 # we need to install a modified version of APStreamline
 # includes defect fixes and the necessary adoptions for the TX2
 # please also follow the wiki for APStreamline on github
-pushd ~/Github
+pushd ~/GitHub
 rm -rf adaptive-streaming
 git clone -b video_streaming https://github.com/mtbsteve/APWeb.git
 pushd adaptive-streaming


### PR DESCRIPTION
Hey, me again! Following my comment on your commit from last week about the "GitHub" syntax, I saw that you changed some of the "GitHub" into "Github". But, it seems to be the other way around as the standard seems to be "GitHub" from the original repository. I encountered the problem at the "./install_pymavlink" line from the setup file. So I changed some of them in this PR to remain consistent, including the ones inside the "install_APWeb" and "setup_APStreamline". I will try installing AP_Streamline today. ;)

EDIT: I took the liberty of adding the command line for installing pip3, you did specified it in the comment, but since it is necessary for meson, better install it anyway, maybe? And I also changed the url for cloning your adaptive-streaming repository, I believe it was a wrong copy-paste?